### PR TITLE
Snake case request body properties

### DIFF
--- a/build/sdk/config.json
+++ b/build/sdk/config.json
@@ -1,5 +1,6 @@
 {
   "usePromises": true,
   "useES6": false,
-  "hideGenerationTimestamp": true
+  "hideGenerationTimestamp": true,
+  "modelPropertyNaming": "snake_case"
 }


### PR DESCRIPTION
`swagger-codegen` is transforming all request body parameters from snake_case -- as defined in the swagger spec -- to camel case. A requst would look something like this: 
```javascript
const searchForShuttles = {
  query: 'space shuttle launch',
  addedDateStart: '1995-01-01',
}

imagesApi.search(searchForShuttles).then(...)
```

This has the potential to cause errors, because our documentation lists body parameters snake cased. With this change, you can now write the above code as: 

```javascript
const searchForShuttles = {
  query: 'space shuttle launch',
  added_date_start: '1995-01-01',
}

imagesApi.search(searchForShuttles).then(...)
```