### PR TITLE
Fix swagger-codegen image at 2.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN node build/swagger/openapiToSwagger.js
 
 ######################################
 
-FROM swaggerapi/swagger-codegen-cli as sdk-build
+FROM swaggerapi/swagger-codegen-cli:2.4.2 as sdk-build
 
 RUN mkdir -p /opt/node-sdk/dist
 


### PR DESCRIPTION
Our `swagger-codegen` image was not registering changes to config.json. Fixing the version at 2.4.2 fixes the problem.