### PR TITLE
DEVPLAT-488: Don't HTML-escape examples

### DIFF
--- a/build/sdk/js/templates/api_doc.mustache
+++ b/build/sdk/js/templates/api_doc.mustache
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 
 {{#vendorExtensions.x-code-samples}}
 ```javascript
-{{source}}
+{{{source}}}
 ```
 {{/vendorExtensions.x-code-samples}}
 {{^vendorExtensions.x-code-samples}}
@@ -99,7 +99,7 @@ Name | Type | Description
 {{#examples}}
 ### Example response
 
-{{example}}
+{{{example}}}
 {{/examples}}
 
 {{/operation}}


### PR DESCRIPTION
swagger-codegen is HTML-escaping the examples pulled in from the swagger file:

```
const sstk &#x3D; require(&quot;shutterstock-api&quot;);

sstk.setAccessToken(process.env.SHUTTERSTOCK_API_TOKEN);

const imagesApi &#x3D; new sstk.ImagesApi();

const collectionId &#x3D; &quot;126351027&quot;
```

The triple braces prevent them from being escaped, per this item: https://github.com/swagger-api/swagger-codegen/issues/661