### PR TITLE
DEVPLAT-590: Broken links to primitives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ script:
   - cp -r ./dist/src ./public-api-javascript-sdk
   - cp ./dist/package.json ./public-api-javascript-sdk
   - cp ./dist/README.md ./public-api-javascript-sdk
-  - sed -i 's/\[\[String\]\]\(String\.md\)/[String]/g' ./dist/docs/*.md
+  - sed -i 's/\[\[String\]\](String.md)/[String]/g' ./dist/docs/*.md
   - cp -r ./dist/docs ./public-api-javascript-sdk
   - cd ./public-api-javascript-sdk
   - nvm install 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script:
   - cp -r ./dist/src ./public-api-javascript-sdk
   - cp ./dist/package.json ./public-api-javascript-sdk
   - cp ./dist/README.md ./public-api-javascript-sdk
+  - sed -i 's/\[\[String\]\]\(String\.md\)/[String]/g' ./dist/docs/*.md
   - cp -r ./dist/docs ./public-api-javascript-sdk
   - cd ./public-api-javascript-sdk
   - nvm install 10


### PR DESCRIPTION
This is a workaround for https://github.com/swagger-api/swagger-codegen/issues/9473. 

When we have a parameter that accepts an array of String, swagger-codegen treats that String like a model type and generates a (broken) link to it:

```
Name | Type | Description
------------- | ------------- | -------------
id (required) | String| Collection ID
item_id | [[String]](String.md)| One or more image IDs to remove from the collection
```

This PR removes those links.