### PR TITLE
DEVPLAT-641: API doesn't always return a data object, so this creates bad examples.

### DIFF
--- a/build/sdk/js/templates/api_doc.mustache
+++ b/build/sdk/js/templates/api_doc.mustache
@@ -52,7 +52,7 @@ const queryParams = { {{#allParams}}{{^required}}
 
 {{#usePromises}}
 api.{{{operationId}}}({{#allParams}}{{#required}}{{{paramName}}}{{#vendorExtensions.x-codegen-hasMoreRequired}}, {{/vendorExtensions.x-codegen-hasMoreRequired}}{{/required}}{{/allParams}}{{#hasOptionalParams}}{{#vendorExtensions.x-codegen-hasRequiredParams}}, {{/vendorExtensions.x-codegen-hasRequiredParams}}queryParams{{/hasOptionalParams}}){{#returnType}}
-  .then(({ data }) => {
+  .then((data) => {
     console.log(data);
   }){{/returnType}}
   .catch((error) => {


### PR DESCRIPTION
For example, this example returns "undefined" because the response from the API is not nested in a `data` object:
https://github.com/shutterstock/public-api-javascript-sdk/blob/master/docs/ImagesApi.md#getImage