### PR TITLE
Fixes casing of customer_ID LicenseRequestMetadata field.

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -10560,7 +10560,7 @@
         },
         "maxProperties": 4,
         "properties": {
-          "customer_id": {
+          "customer_ID": {
             "description": "The ID of a revenue-sharing partner's customer",
             "type": "string"
           },


### PR DESCRIPTION
Using the casing `customer_id` that Swagger generates, we receive `"error": "Metadata is required"`

It *seems* like the correct identifier is `customer_ID`, which works for us.