### PR TITLE
remove-extra-quotes-in-examples

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,4 +26,6 @@ COPY build/sdk/config.json .
 
 RUN java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate -i ./swagger2.json -o ./dist -c ./config.json -l javascript -t ./build/sdk/js/templates
 
+RUN sed -i 's/\\"//g' ./dist/docs/*
+
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
**Issue Description**
The generated examples from swagger-codegen add an extra pair of quotes where they are not needed, such as the `embed` and `type` params in this generated example:

```javascript
const sstk = require('shutterstock-api');

// To use OAuth access token authorization:
sstk.setAccessToken(process.env.SHUTTERSTOCK_API_TOKEN);

const api = new sstk.ImagesApi();

const queryParams =

{ 'embed': "\"share_url\"", // String | Which sharing information to include in the response, such as a URL to the collection 'type': ["\"photo\""], // [String] | The types of collections to return 'asset_hint': "1x" // String | Cover image size, defaults to 1x }

;

api.getFeaturedLightboxList(queryParams)
.then((data) =>

{ console.log(data); }

)
.catch((error) =>

{ console.error(error); }

);

```

It's probably this swagger-codegen [issue](https://github.com/swagger-api/swagger-codegen/issues/5460), which is still unresolved.  Hence with this change, we can workaround the issue and remove the extraneous quotes



**How was this tested ?**
1. Generate a new docker image like so:
```
docker build -t remove-extra-quotes-in-examples .
```

2. Executed the build like so:
```
docker run -it remove-extra-quotes-in-examples
```

3. Spot checked that the docs generated in the `./dist/docs/*` directory do not contain extra quotes.