### PR TITLE
DEVPLAT-843: Remove codegen hack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN node build/swagger/openapiToSwagger.js
 
 ######################################
 
-FROM swaggerapi/swagger-codegen-cli:2.4.2 as sdk-build
+FROM swaggerapi/swagger-codegen-cli:2.4.9 as sdk-build
 
 RUN mkdir -p /opt/node-sdk/dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,4 @@ COPY build/sdk/config.json .
 
 RUN java -jar /opt/swagger-codegen-cli/swagger-codegen-cli.jar generate -i ./swagger2.json -o ./dist -c ./config.json -l javascript -t ./build/sdk/js/templates
 
-RUN sed -i 's/\\"//g' ./dist/docs/*
-
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Shweta added a hack in #99 to fix examples that get double quotes, but version 2.4.9 of swagger-codegen makes this hack unnecessary.